### PR TITLE
ext_newgrid was renamed to ext_linegrid

### DIFF
--- a/neovim.cpp/include/neovim.hpp
+++ b/neovim.cpp/include/neovim.hpp
@@ -88,7 +88,7 @@ class neovim: public nvim::nvim_api, public nvim::nvim_ui
         void print();
     };
 
-    //ext_newgrid
+    //ext_linegrid
     struct hl_attr
     {
         unordered_map<String, Object> rgb_attr;
@@ -126,8 +126,8 @@ public:
 
     Vector<colors_map> nvim_colors_map;
 
-//ext_newgrid option
-    bool is_ext_newgrid;
+//ext_linegrid option
+    bool is_ext_linegrid;
 
     Vector<hl_attr> nvim_hl_attr;
 

--- a/neovim.cpp/src/main.cpp
+++ b/neovim.cpp/src/main.cpp
@@ -7,7 +7,7 @@ using std::endl;
 
 int main(int argc, char* argv[])
 {
-    neovim nvim(100, 55, {{"rgb", true}, {"ext_newgrid", true}});
+    neovim nvim(100, 55, {{"rgb", true}, {"ext_linegrid", true}});
     nvim.connect_tcp("localhost", "6666");
     nvim.nvim_ui_attach();
 

--- a/neovim.cpp/src/neovim.cpp
+++ b/neovim.cpp/src/neovim.cpp
@@ -11,8 +11,8 @@ neovim::neovim(uint width, uint height, const Dictionary& options)
         ui_options[boost::get<String>(key)] = val;
     }
 
-    try{ is_ext_newgrid = boost::get<bool>(ui_options.at("ext_newgrid")); }
-    catch(std::out_of_range){ is_ext_newgrid = false; }
+    try{ is_ext_linegrid = boost::get<bool>(ui_options.at("ext_linegrid")); }
+    catch(std::out_of_range){ is_ext_linegrid = false; }
 
     nvim_screen.resize(height);
     for(auto& line: nvim_screen){ line.resize(width*2, ' '); }

--- a/src/PakuVim.cpp
+++ b/src/PakuVim.cpp
@@ -4,7 +4,7 @@ void PakuVim::set_neovim_html()
 {
     if(!need_update){ return; }
     QString screen;
-    if(is_ext_newgrid)
+    if(is_ext_linegrid)
     {
         auto [drf, dgf, dbf] = nvim_html::convert_rgb(
                 boost::get<uInteger>(nvim_hl_attr.at(0).rgb_attr.at("foreground")));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char* argv[])
     // QHBoxLayout glayout;
     constexpr int width = 101;
     constexpr int height = 56;
-    PakuVim pakuvim(width, height, {{"rgb", true}, {"ext_newgrid", true}});
+    PakuVim pakuvim(width, height, {{"rgb", true}, {"ext_linegrid", true}});
     pakuvim.connect_tcp("localhost", argv[1], 100);
     pakuvim.nvim_ui_attach();
     // pakuvim.QWidget::resize((width + 2)*8, (height + 5)*16);


### PR DESCRIPTION
Just a headsup that nvim core renamed the new UI extension `ext_newgrid` which this UI uses, to `ext_linegrid` on latest master. This UI will need to be changed to use the new name, sorry for the annoyance. I think this patch should be enough, but I haven't tested it.

 Ref https://github.com/neovim/neovim/pull/9064